### PR TITLE
Refactor: Consolidate utility functions

### DIFF
--- a/stemprover/src/stemprover/__init__.py
+++ b/stemprover/src/stemprover/__init__.py
@@ -21,8 +21,8 @@ from .analysis.base import VocalAnalyzer
 from .analysis.spectral import SpectralAnalyzer
 #from .analysis.phase import PhaseAnalyzer
 # TODO: Implement PhaseAnalyzer using existing phase analysis infrastructure
-# - Consolidate phase-related functions from common/math_utils.py
-# - Incorporate phase complexity calculations from audio_utils.py
+# - Consolidate phase-related functions from the new utils.py
+# - Incorporate phase complexity calculations from the new utils.py
 # - Consider alpha-channel visualization integration
 # (Postponed until after band-split validation experiment)
 

--- a/stemprover/src/stemprover/analysis/artifacts/base.py
+++ b/stemprover/src/stemprover/analysis/artifacts/base.py
@@ -1,5 +1,5 @@
-from ...common.types import AudioArray, SpectrogramArray, TensorType
-from ...common.audio_utils import create_spectrogram
+from ...types import AudioArray, SpectrogramArray, TensorType
+from ...utils import create_spectrogram
 
 from abc import ABC, abstractmethod
 import numpy as np

--- a/stemprover/src/stemprover/analysis/selection/segment_finder.py
+++ b/stemprover/src/stemprover/analysis/selection/segment_finder.py
@@ -3,10 +3,9 @@ from typing import List, Dict, Tuple
 import numpy as np
 import librosa
 
-from stemprover.common.types import AudioArray, SpectrogramArray
-from stemprover.common.audio_utils import create_spectrogram, calculate_onset_variation
-from stemprover.common.spectral_utils import calculate_band_energy
-from stemprover.core.types import ProcessingConfig
+from ...types import AudioArray, SpectrogramArray
+from ...utils import create_spectrogram, calculate_onset_variation, calculate_band_energy
+from ...core.types import ProcessingConfig
 from .metrics import SegmentMetrics
 from stemprover.core.audio import AudioSegment
 from stemprover.core.types import (

--- a/stemprover/src/stemprover/analysis/spectral.py
+++ b/stemprover/src/stemprover/analysis/spectral.py
@@ -4,14 +4,12 @@ import matplotlib.pyplot as plt
 from typing import Dict, Optional
 from datetime import datetime
 
-from ..common.types import (
+from ..types import (
     AudioArray, SpectrogramArray, FrequencyBands,
     DEFAULT_FREQUENCY_BANDS
 )
-from ..common.audio_utils import (
-    create_spectrogram, get_frequency_bins, get_band_mask
-)
-from ..common.math_utils import (
+from ..utils import (
+    create_spectrogram, get_frequency_bins, get_band_mask,
     magnitude, angle, phase_difference, phase_coherence,
     rms, db_scale
 )

--- a/stemprover/src/stemprover/preparation/segments/generator.py
+++ b/stemprover/src/stemprover/preparation/segments/generator.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass
 from torch.utils.data import Dataset, DataLoader
 import numpy as np
 
-from common.types import AudioArray
-from common.audio_utils import create_spectrogram
-from core.audio import AudioSegment
-from core.types import ProcessingConfig
+from ...types import AudioArray
+from ...utils import create_spectrogram
+from ...core.audio import AudioSegment
+from ...core.types import ProcessingConfig
 
 """
 Key features:


### PR DESCRIPTION
This commit consolidates various utility functions from the `stemprover.common` module into a new, centralized `stemprover.utils` module. This is done to reduce code duplication and improve the overall structure of the project.

The `common` directory, which previously contained `audio_utils.py`, `math_utils.py`, `spectral_utils.py`, and `types.py`, has been removed. The functions and types from these files have been moved to `stemprover.utils` and `stemprover.types` respectively.

All affected files have been updated to import from the new modules.